### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   lint-and-build:
     name: Lint, Type Check and Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/Elcapitanoe/buildprop-webpage/security/code-scanning/9](https://github.com/Elcapitanoe/buildprop-webpage/security/code-scanning/9)

The issue can be resolved by adding a `permissions` block to limit the access of `GITHUB_TOKEN`. Since the workflow only requires read access to repository contents, the minimal permissions needed are `contents: read`. This block should be added at the job level or workflow level to restrict permissions accordingly.

Steps:
1. Add a `permissions` block under the `jobs` section for the `lint-and-build` job.
2. Specify `contents: read` in the `permissions` block to restrict access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
