### PR TITLE
Improve GitHub rate limit detection

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,6 +4,8 @@ declare const __BUILD_TIME__: string;
 interface ImportMetaEnv {
   readonly GH_TOKEN?: string;
   readonly VITE_GH_TOKEN?: string;
+  readonly GITHUB_TOKEN?: string;
+  readonly VITE_GITHUB_TOKEN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- broaden GitHub token detection to use common environment variable names in both Node and Vite contexts
- read the core rate limit payload when headers are missing to accurately reflect authenticated limits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9f01f1278832f944eedf268f75f80